### PR TITLE
Fix weighted average double round up

### DIFF
--- a/src/math/PercentageMath.sol
+++ b/src/math/PercentageMath.sol
@@ -112,12 +112,9 @@ library PercentageMath {
         // Must revert if
         //     percentage > PERCENTAGE_FACTOR
         // or if
-        //     x * (PERCENTAGE_FACTOR - percentage) > type(uint256).max
-        //     <=> PERCENTAGE_FACTOR - percentage > 0 and x > type(uint256).max / (PERCENTAGE_FACTOR - percentage)
-        // or if
         //     y * percentage + HALF_PERCENTAGE_FACTOR > type(uint256).max
         //     <=> percentage > 0 and y > (type(uint256).max - percentage) / percentage
-        // or if (assuming that the 3 previous conditions are false)
+        // or if
         //     x * (PERCENTAGE_FACTOR - percentage) + y * percentage + HALF_PERCENTAGE_FACTOR > type(uint256).max
         //     <=> x > type(uint256).max - y * percentage - HALF_PERCENTAGE_FACTOR / (PERCENTAGE_FACTOR - percentage)
         assembly {
@@ -125,11 +122,8 @@ library PercentageMath {
             if or(
                 gt(percentage, PERCENTAGE_FACTOR),
                 or(
-                    or(
-                        mul(percentage, gt(y, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, percentage))),
-                        mul(z, gt(x, div(MAX_UINT256, z)))
-                    ),
-                    gt(mul(x, z), sub(sub(MAX_UINT256, mul(y, percentage)), HALF_PERCENTAGE_FACTOR))
+                    mul(percentage, gt(y, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, percentage))),
+                    mul(z, gt(x, div(sub(sub(MAX_UINT256, mul(y, percentage)), HALF_PERCENTAGE_FACTOR), z)))
                 )
             ) {
                 revert(0, 0)

--- a/src/math/PercentageMath.sol
+++ b/src/math/PercentageMath.sol
@@ -116,14 +116,14 @@ library PercentageMath {
         //     <=> percentage > 0 and y > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / percentage
         // or if
         //     x * (PERCENTAGE_FACTOR - percentage) + y * percentage + HALF_PERCENTAGE_FACTOR > type(uint256).max
-        //     <=> (PERCENTAGE_FACTOR - percentage) > 0 and x > (type(uint256).max - y * percentage - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR - percentage)
+        //     <=> (PERCENTAGE_FACTOR - percentage) > 0 and x > (type(uint256).max - HALF_PERCENTAGE_FACTOR - y * percentage) / (PERCENTAGE_FACTOR - percentage)
         assembly {
             z := sub(PERCENTAGE_FACTOR, percentage) // Temporary assignment to save gas.
             if or(
                 gt(percentage, PERCENTAGE_FACTOR),
                 or(
                     mul(percentage, gt(y, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, percentage))),
-                    mul(z, gt(x, div(sub(sub(MAX_UINT256, mul(y, percentage)), HALF_PERCENTAGE_FACTOR), z)))
+                    mul(z, gt(x, div(sub(MAX_UINT256_MINUS_HALF_PERCENTAGE, mul(y, percentage)), z)))
                 )
             ) {
                 revert(0, 0)

--- a/src/math/PercentageMath.sol
+++ b/src/math/PercentageMath.sol
@@ -113,10 +113,10 @@ library PercentageMath {
         //     percentage > PERCENTAGE_FACTOR
         // or if
         //     y * percentage + HALF_PERCENTAGE_FACTOR > type(uint256).max
-        //     <=> percentage > 0 and y > (type(uint256).max - percentage) / percentage
+        //     <=> percentage > 0 and y > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / percentage
         // or if
         //     x * (PERCENTAGE_FACTOR - percentage) + y * percentage + HALF_PERCENTAGE_FACTOR > type(uint256).max
-        //     <=> x > type(uint256).max - y * percentage - HALF_PERCENTAGE_FACTOR / (PERCENTAGE_FACTOR - percentage)
+        //     <=> (PERCENTAGE_FACTOR - percentage) > 0 and x > (type(uint256).max - y * percentage - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR - percentage)
         assembly {
             z := sub(PERCENTAGE_FACTOR, percentage) // Temporary assignment to save gas.
             if or(

--- a/test/TestPercentageMath.sol
+++ b/test/TestPercentageMath.sol
@@ -168,9 +168,8 @@ contract TestPercentageMath is Test {
         uint16 percentage
     ) public {
         vm.assume(percentage <= 1e4);
-        vm.assume(percentage == 1e4 || x <= type(uint256).max / (1e4 - percentage));
         vm.assume(percentage == 0 || y <= (type(uint256).max - 0.5e4) / percentage);
-        vm.assume(x * (1e4 - percentage) <= type(uint256).max - y * percentage - 0.5e4);
+        vm.assume(1e4 - percentage == 0 || x <= (type(uint256).max - y * percentage - 0.5e4) / (1e4 - percentage));
 
         assertEq(PercentageMath.weightedAvg(x, y, percentage), mathRef.weightedAvg(x, y, percentage));
     }
@@ -181,11 +180,9 @@ contract TestPercentageMath is Test {
         uint256 percentage
     ) public {
         vm.assume(percentage <= 1e4);
-        // prettier-ignore
         vm.assume(
-            ( percentage != 1e4 && x > type(uint256).max / (1e4 - percentage) )         || 
-            ( percentage != 0   && y > (type(uint256).max - 0.5e4) / percentage )       ||
-            x * (1e4 - percentage) > type(uint256).max - y * percentage - 0.5e4
+            (percentage != 0 && y > (type(uint256).max - 0.5e4) / percentage) ||
+                ((1e4 - percentage) != 0 && x > (type(uint256).max - y * percentage - 0.5e4) / (1e4 - percentage))
         );
 
         vm.expectRevert();

--- a/test/TestPercentageMath.sol
+++ b/test/TestPercentageMath.sol
@@ -167,9 +167,12 @@ contract TestPercentageMath is Test {
         uint256 y,
         uint16 percentage
     ) public {
-        vm.assume(percentage <= 1e4);
-        vm.assume(percentage == 0 || y <= (type(uint256).max - 0.5e4) / percentage);
-        vm.assume(1e4 - percentage == 0 || x <= (type(uint256).max - y * percentage - 0.5e4) / (1e4 - percentage));
+        vm.assume(percentage <= PERCENTAGE_FACTOR);
+        vm.assume(percentage == 0 || y <= (MAX_UINT256 - HALF_PERCENTAGE_FACTOR) / percentage);
+        vm.assume(
+            PERCENTAGE_FACTOR - percentage == 0 ||
+                x <= (MAX_UINT256 - y * percentage - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR - percentage)
+        );
 
         assertEq(PercentageMath.weightedAvg(x, y, percentage), mathRef.weightedAvg(x, y, percentage));
     }
@@ -179,10 +182,11 @@ contract TestPercentageMath is Test {
         uint256 y,
         uint256 percentage
     ) public {
-        vm.assume(percentage <= 1e4);
+        vm.assume(percentage <= PERCENTAGE_FACTOR);
         vm.assume(
-            (percentage != 0 && y > (type(uint256).max - 0.5e4) / percentage) ||
-                ((1e4 - percentage) != 0 && x > (type(uint256).max - y * percentage - 0.5e4) / (1e4 - percentage))
+            (percentage != 0 && y > (MAX_UINT256 - HALF_PERCENTAGE_FACTOR) / percentage) ||
+                ((PERCENTAGE_FACTOR - percentage) != 0 &&
+                    x > (MAX_UINT256 - y * percentage - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR - percentage))
         );
 
         vm.expectRevert();


### PR DESCRIPTION
Fixes [this](https://github.com/morpho-dao/morpho-utils/pull/41#discussion_r946620510) issue found by @QGarchery.
Unexpected, but it is saving gas !
Notice that the reverts for overflows are much more conservative with this solution, but I don't think that this is much of an issue.