### PR TITLE
Optimize min and max

### DIFF
--- a/src/math/Math.sol
+++ b/src/math/Math.sol
@@ -10,7 +10,7 @@ library Math {
 
     function max(uint256 x, uint256 y) internal pure returns (uint256 z) {
         assembly {
-            z := xor(x, mul(xor(x, y), lt(x, y)))
+            z := xor(x, mul(xor(x, y), gt(y, x)))
         }
     }
 

--- a/src/math/Math.sol
+++ b/src/math/Math.sol
@@ -4,13 +4,13 @@ pragma solidity ^0.8.0;
 library Math {
     function min(uint256 x, uint256 y) internal pure returns (uint256 z) {
         assembly {
-            z := add(mul(x, lt(x, y)), mul(y, iszero(lt(x, y))))
+            z := xor(x, mul(xor(x, y), lt(y, x)))
         }
     }
 
     function max(uint256 x, uint256 y) internal pure returns (uint256 z) {
         assembly {
-            z := add(mul(x, gt(x, y)), mul(y, iszero(gt(x, y))))
+            z := xor(x, mul(xor(x, y), lt(x, y)))
         }
     }
 


### PR DESCRIPTION
Ain't much, but it's honest work. Saves around 8 gas.

Somehow `.gas-snapshot` is under `.gitignore`. Is this intended?