### PR TITLE
Add memory-safe NatSpec tag to assembly blocks

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,7 +1,5 @@
 [profile.default]
-src = 'src'
-out = 'out'
-libs = ['lib']
+via-ir = true
 fuzz_runs = 1024
 gas_reports = ["*"]
 

--- a/src/math/CompoundMath.sol
+++ b/src/math/CompoundMath.sol
@@ -15,6 +15,7 @@ library CompoundMath {
     /// INTERNAL ///
 
     function mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        /// @solidity memory-safe-assembly
         assembly {
             // Revert if x * y > type(uint256).max
             // <=> y > 0 and x > type(uint256).max / y
@@ -27,6 +28,7 @@ library CompoundMath {
     }
 
     function div(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        /// @solidity memory-safe-assembly
         assembly {
             // Revert if x * SCALE > type(uint256).max or y == 0
             // <=> x > type(uint256).max / SCALE or y == 0

--- a/src/math/Math.sol
+++ b/src/math/Math.sol
@@ -3,12 +3,14 @@ pragma solidity ^0.8.0;
 
 library Math {
     function min(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        /// @solidity memory-safe-assembly
         assembly {
             z := xor(x, mul(xor(x, y), lt(y, x)))
         }
     }
 
     function max(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        /// @solidity memory-safe-assembly
         assembly {
             z := xor(x, mul(xor(x, y), gt(y, x)))
         }
@@ -16,6 +18,7 @@ library Math {
 
     /// @dev Returns max(x - y, 0).
     function zeroFloorSub(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        /// @solidity memory-safe-assembly
         assembly {
             z := mul(gt(x, y), sub(x, y))
         }
@@ -23,6 +26,7 @@ library Math {
 
     /// @dev Returns x / y rounded up (x / y + boolAsInt(x % y > 0)).
     function divUp(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        /// @solidity memory-safe-assembly
         assembly {
             // Revert if y = 0
             if iszero(y) {

--- a/src/math/PercentageMath.sol
+++ b/src/math/PercentageMath.sol
@@ -26,6 +26,7 @@ library PercentageMath {
         // <=> percentage > type(uint256).max - PERCENTAGE_FACTOR
         //     or x > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR + percentage)
         // Note: PERCENTAGE_FACTOR + percentage >= PERCENTAGE_FACTOR > 0
+        /// @solidity memory-safe-assembly
         assembly {
             y := add(PERCENTAGE_FACTOR, percentage) // Temporary assignment to save gas.
 
@@ -50,6 +51,7 @@ library PercentageMath {
         //     or x * (PERCENTAGE_FACTOR - percentage) + HALF_PERCENTAGE_FACTOR > type(uint256).max
         // <=> percentage > PERCENTAGE_FACTOR
         //     or ((PERCENTAGE_FACTOR - percentage) > 0 and x > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR - percentage))
+        /// @solidity memory-safe-assembly
         assembly {
             y := sub(PERCENTAGE_FACTOR, percentage) // Temporary assignment to save gas.
 
@@ -69,6 +71,7 @@ library PercentageMath {
         // Must revert if
         // x * percentage + HALF_PERCENTAGE_FACTOR > type(uint256).max
         // <=> percentage > 0 and x > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / percentage
+        /// @solidity memory-safe-assembly
         assembly {
             if mul(percentage, gt(x, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, percentage))) {
                 revert(0, 0)
@@ -88,6 +91,7 @@ library PercentageMath {
         //     or x * PERCENTAGE_FACTOR + percentage / 2 > type(uint256).max
         // <=> percentage == 0
         //     or x > (type(uint256).max - percentage / 2) / PERCENTAGE_FACTOR
+        /// @solidity memory-safe-assembly
         assembly {
             y := div(percentage, 2) // Temporary assignment to save gas.
 
@@ -117,6 +121,7 @@ library PercentageMath {
         // or if
         //     x * (PERCENTAGE_FACTOR - percentage) + y * percentage + HALF_PERCENTAGE_FACTOR > type(uint256).max
         //     <=> (PERCENTAGE_FACTOR - percentage) > 0 and x > (type(uint256).max - HALF_PERCENTAGE_FACTOR - y * percentage) / (PERCENTAGE_FACTOR - percentage)
+        /// @solidity memory-safe-assembly
         assembly {
             z := sub(PERCENTAGE_FACTOR, percentage) // Temporary assignment to save gas.
             if or(

--- a/src/math/WadRayMath.sol
+++ b/src/math/WadRayMath.sol
@@ -29,6 +29,7 @@ library WadRayMath {
         // Overflow if (x * y + HALF_WAD) > type(uint256).max
         // <=> x * y > type(uint256).max - HALF_WAD
         // <=> x > (type(uint256).max - HALF_WAD) / y
+        /// @solidity memory-safe-assembly
         assembly {
             if mul(y, gt(x, div(MAX_UINT256_MINUS_HALF_WAD, y))) {
                 revert(0, 0)
@@ -47,6 +48,7 @@ library WadRayMath {
         // Overflow if (x * WAD + y / 2) > type(uint256).max
         // <=> x * WAD > type(uint256).max - y / 2
         // <=> x > (type(uint256).max - y / 2) / WAD
+        /// @solidity memory-safe-assembly
         assembly {
             z := div(y, 2)
             if iszero(mul(y, iszero(gt(x, div(sub(MAX_UINT256, z), WAD))))) {
@@ -66,6 +68,7 @@ library WadRayMath {
         // Overflow if (x * y + HALF_RAY) > type(uint256).max
         // <=> x * y > type(uint256).max - HALF_RAY
         // <=> x > (type(uint256).max - HALF_RAY) / y
+        /// @solidity memory-safe-assembly
         assembly {
             if mul(y, gt(x, div(MAX_UINT256_MINUS_HALF_RAY, y))) {
                 revert(0, 0)
@@ -84,6 +87,7 @@ library WadRayMath {
         // Overflow if (x * RAY + y / 2) > type(uint256).max
         // <=> x * RAY > type(uint256).max - y / 2
         // <=> x > (type(uint256).max - y / 2) / RAY
+        /// @solidity memory-safe-assembly
         assembly {
             z := div(y, 2)
             if iszero(mul(y, iszero(gt(x, div(sub(MAX_UINT256, z), RAY))))) {
@@ -98,6 +102,7 @@ library WadRayMath {
     /// @param x Ray.
     /// @return y = x converted to wad, rounded half up to the nearest wad.
     function rayToWad(uint256 x) internal pure returns (uint256 y) {
+        /// @solidity memory-safe-assembly
         assembly {
             // If x % WAD_RAY_RATIO >= HALF_WAD_RAY_RATIO, round up.
             y := add(div(x, WAD_RAY_RATIO), iszero(lt(mod(x, WAD_RAY_RATIO), HALF_WAD_RAY_RATIO)))
@@ -108,6 +113,7 @@ library WadRayMath {
     /// @param x Wad.
     /// @return y = x converted in ray.
     function wadToRay(uint256 x) internal pure returns (uint256 y) {
+        /// @solidity memory-safe-assembly
         assembly {
             y := mul(WAD_RAY_RATIO, x)
             // Revert if y / WAD_RAY_RATIO != x


### PR DESCRIPTION
This PR requires the reviewer to be aware of the following:
- https://docs.soliditylang.org/en/v0.8.17/assembly.html#memory-safety

### In particular, please note the Solidity documentation states:

> Inline assembly that neither involves any operations that access memory nor assigns to any Solidity variables in memory is automatically considered memory-safe and does not need to be annotated.

However, it seems to not be the case when I compile the following with Solidity 0.8.16 without the optimizer and with IR:

```solidity
contract Test {
  using CompountMath for uint256;

  function test() {
    uint256 a = uint256(1).mul(1 ether);
  }
}
```

Because I get the error:

```bash
Variable _2 is 1 too deep in the stack [ _2 expr_mpos_3 _6 _18 _1 _16 expr_component_mpos_1 _10 RET var_ins_mpos _4 _7 _3 _14 var_i expr_1 _29 ]
No memoryguard was present. Consider using memory-safe assembly only and annotating it via 'assembly ("memory-safe") { ... }'.
```

> In case you are developing a library that is meant to be compatible across multiple versions of Solidity, you can use a special comment to annotate an assembly block as memory-safe