### PR TITLE
perf: compound math div

### DIFF
--- a/src/math/CompoundMath.sol
+++ b/src/math/CompoundMath.sol
@@ -9,7 +9,6 @@ library CompoundMath {
     /// CONSTANTS ///
 
     uint256 internal constant MAX_UINT256 = 2**256 - 1;
-    uint256 public constant SCALE = 1e36;
     uint256 public constant WAD = 1e18;
 
     /// INTERNAL ///
@@ -28,13 +27,13 @@ library CompoundMath {
 
     function div(uint256 x, uint256 y) internal pure returns (uint256 z) {
         assembly {
-            // Revert if x * SCALE > type(uint256).max or y == 0
-            // <=> x > type(uint256).max / SCALE or y == 0
-            if iszero(mul(y, iszero(gt(x, div(MAX_UINT256, SCALE))))) {
+            // Revert if x * WAD > type(uint256).max or y == 0
+            // <=> x > type(uint256).max / WAD or y == 0
+            if iszero(mul(y, iszero(gt(x, div(MAX_UINT256, WAD))))) {
                 revert(0, 0)
             }
 
-            z := div(div(mul(SCALE, x), y), WAD)
+            z := div(mul(WAD, x), y)
         }
     }
 }

--- a/test/TestCompoundMath.sol
+++ b/test/TestCompoundMath.sol
@@ -66,7 +66,7 @@ contract TestCompoundMath is Test {
 
     function testDivOverflow(uint256 x, uint256 y) public {
         unchecked {
-            vm.assume(x > 0 && (x * SCALE) / x != SCALE);
+            vm.assume(x > 0 && (x * WAD) / x != WAD);
         }
 
         vm.expectRevert();


### PR DESCRIPTION
Trying to formally prove CompoundMath (#59), I realized that some computations on the `div` functions where unnecessary.

Instead of doing `SCALE` x `x` / `y` / `WAD`, we can simply do `WAD` x `x` / `y`.

Note that I didn't modified the non-overflowing test, because we are comparing against Compound's library (in fact not really). 