### PR TITLE
Make imports relative

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -1,4 +1,0 @@
-@aave/core-v3/=lib/aave-v3-core/
-ds-test/=lib/forge-std/lib/ds-test/src/
-forge-std/=lib/forge-std/src/
-openzeppelin-contracts/=lib/openzeppelin-contracts/

--- a/test/TestCompoundMath.sol
+++ b/test/TestCompoundMath.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import {CompoundMathMock} from "./mocks/CompoundMathMock.sol";
 import {CompoundMathRef} from "./references/CompoundMathRef.sol";
-import "forge-std/Test.sol";
+import "../lib/forge-std/src/Test.sol";
 
 contract TestCompoundMath is Test {
     CompoundMathMock mock;

--- a/test/TestDelegateCall.sol
+++ b/test/TestDelegateCall.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.0;
 
-import "forge-std/Vm.sol";
-import "forge-std/Test.sol";
+import {Address} from "../lib/openzeppelin-contracts/contracts/utils/Address.sol";
+
 import "src/DelegateCall.sol";
-import "openzeppelin-contracts/contracts/utils/Address.sol";
+import "../lib/forge-std/src/Test.sol";
 
 contract Caller {
     using DelegateCall for address;

--- a/test/TestMath.sol
+++ b/test/TestMath.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import {MathMock} from "./mocks/MathMock.sol";
 import {MathRef} from "./references/MathRef.sol";
-import "forge-std/Test.sol";
+import "../lib/forge-std/src/Test.sol";
 
 contract TestMath is Test {
     MathMock mock;

--- a/test/TestPercentageMath.sol
+++ b/test/TestPercentageMath.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import {PercentageMathMock} from "./mocks/PercentageMathMock.sol";
 import {PercentageMathRef} from "./references/PercentageMathRef.sol";
-import "forge-std/Test.sol";
+import "../lib/forge-std/src/Test.sol";
 
 contract TestPercentageMath is Test {
     uint256 internal constant PERCENTAGE_FACTOR = 100_00;

--- a/test/TestWadRayMath.sol
+++ b/test/TestWadRayMath.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import {WadRayMathMock} from "./mocks/WadRayMathMock.sol";
 import {WadRayMathRef} from "./references/WadRayMathRef.sol";
-import "forge-std/Test.sol";
+import "../lib/forge-std/src/Test.sol";
 
 contract TestWadRayMath is Test {
     uint256 internal constant WAD = 1e18;

--- a/test/references/PercentageMathRef.sol
+++ b/test/references/PercentageMathRef.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.0;
 
-import {PercentageMath} from "@aave/core-v3/contracts/protocol/libraries/math/PercentageMath.sol";
+import {PercentageMath} from "../../lib/aave-v3-core/contracts/protocol/libraries/math/PercentageMath.sol";
 
 contract PercentageMathRef {
     function percentAdd(uint256 x, uint256 y) public pure returns (uint256) {

--- a/test/references/WadRayMathRef.sol
+++ b/test/references/WadRayMathRef.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.0;
 
-import {WadRayMath} from "@aave/core-v3/contracts/protocol/libraries/math/WadRayMath.sol";
+import {WadRayMath} from "../../lib/aave-v3-core/contracts/protocol/libraries/math/WadRayMath.sol";
 
 contract WadRayMathRef {
     function wadMul(uint256 x, uint256 y) public pure returns (uint256) {


### PR DESCRIPTION
This PR implements solution 2) described in https://github.com/morpho-dao/morpho-utils/issues/79

Please read the issue & the discussion first!!
This PR is obviously unnecessary because contracts don't depend on any dependencies in this repository. But this is for illustrative purposes. I may replicate this PR in `morpho-data-structures` to illustrate better

Sometimes, you have to make ugly choices to keep backward compatibility...